### PR TITLE
Support producing messages with AvroSchema

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -53,7 +53,10 @@ jobs:
         run: ./pulsar-test-service-start.sh
 
       - name: Run unit tests
-        run: ./build/src/IntSchemaExample
+        run: |
+          set -e
+          ./build/src/IntSchemaExample
+          ./build/src/AvroSchemaExample
 
       - name: Stop Pulsar service
         run: ./pulsar-test-service-stop.sh

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -46,6 +46,7 @@ jobs:
       - name: Build
         run: |
           ./bin/install-pulsar-cpp.sh
+          ./bin/install-avro-cpp.sh
           cmake -B build -DCMAKE_PREFIX_PATH=$PWD/installed
           cmake --build build
 

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -47,6 +47,7 @@ jobs:
         run: |
           ./bin/install-pulsar-cpp.sh
           ./bin/install-avro-cpp.sh
+          export LD_LIBRARY_PATH=$PWD/installed/lib
           cmake -B build -DCMAKE_PREFIX_PATH=$PWD/installed
           cmake --build build
 
@@ -57,6 +58,7 @@ jobs:
         run: |
           set -e
           ./build/src/IntSchemaExample
+          export LD_LIBRARY_PATH=$PWD/installed/lib
           ./build/src/AvroSchemaExample
 
       - name: Stop Pulsar service

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,12 @@
 # CMake directory created by ./bin/build-pulsar-cpp.sh
 build/
 build-pulsar/
+build-avro/
 dependencies/
 installed/
+
+# Created by ./pulsar-test-service-start.sh
+.container-id.txt
 
 # Compiled Object files
 *.slo

--- a/bin/install-avro-cpp.sh
+++ b/bin/install-avro-cpp.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -ex
+ROOT=$(cd $(dirname $0)/.. && pwd)
+
+git submodule update --init
+
+mkdir -p installed && cd installed
+PREFIX=$PWD
+
+# Use the same Boost version with pulsar-client-cpp
+cp ../pulsar-client-cpp/build-support/dep-version.py .
+cp ../pulsar-client-cpp/dependencies.yaml .
+
+# Install Boost libraries, which are depended by avro-cpp
+if [[ ! -f .avro-boost-done ]]; then
+  BOOST_VERSION=$(./dep-version.py boost)
+  BOOST_VERSION_UNDESRSCORE=$(echo ${BOOST_VERSION} | sed 's/\./_/g')
+  DIR=boost_${BOOST_VERSION_UNDESRSCORE}
+  curl -O -L https://boostorg.jfrog.io/artifactory/main/release/$BOOST_VERSION/source/$DIR.tar.gz
+  tar zxf $DIR.tar.gz
+  cd $DIR
+  ./bootstrap.sh --prefix=$PREFIX --with-libraries=filesystem,iostreams,program_options,regex,system
+  ./b2 install -j8
+  cd -
+  rm -rf $DIR*
+  touch .avro-boost-done
+fi
+
+# Install avro-cpp
+# Don't use 1.11.1, see https://issues.apache.org/jira/browse/AVRO-3601
+AVRO_VERSION=1.11.0
+if [[ ! -f .avro-done ]]; then
+  curl -O -L http://archive.apache.org/dist/avro/avro-$AVRO_VERSION/cpp/avro-cpp-$AVRO_VERSION.tar.gz
+  tar zxf avro-cpp-$AVRO_VERSION.tar.gz
+  cd avro-cpp-$AVRO_VERSION/
+  cmake -B build-avro -DCMAKE_PREFIX_PATH=$PREFIX -DCMAKE_INSTALL_PREFIX=$PREFIX
+  cmake --build build-avro -j8 --target install
+  cd -
+  rm -rf avro-cpp*
+  touch .avro-done
+fi

--- a/include/pulsar/schema/AvroSchema.h
+++ b/include/pulsar/schema/AvroSchema.h
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#pragma once
+
+#include <pulsar/Client.h>
+#include <pulsar/TypedMessageBuilder.h>
+
+// Fix compilation errors when including cstring
+#include <string.h>
+
+namespace pulsar {
+
+namespace schema {
+
+/**
+ * To use this schema, you have to implement `avro::codec_traits<T>` if `T` is not generated from the
+ * `avrogencpp` binary.
+ *
+ * For example, given the following C struct:
+ *
+ * ```c++
+ * struct User {
+ *   std::string name;
+ *   int age;
+ *   char opaque[100]; // Assuming you don't want to encode this field
+ * };
+ * ```
+ *
+ * You should implement the following template specialization like:
+ *
+ * ```c++
+ * namespace avro {
+ *
+ * template <>
+ * struct codec_traits<User> {
+ *   static void encode(avro::Encoder& e, const User& user) {
+ *     avro::encode(e, user.name);
+ *     e.encodeUnionIndex(1);
+ *     avro::encode(e, user.age);
+ *   };
+ *
+ *   static void decode(avro::Decoder& d, User& user) {
+ *     avro::decode(d, user.name);
+ *     d.decodeUnionIndex();
+ *     avro::decode(d, user.age);
+ *   };
+ * };
+ *
+ * }  // namespace avro
+ * ```
+ */
+template <typename T>
+class AvroSchema {
+   public:
+    AvroSchema(const std::string& schema) : schemaInfo_(SchemaType::AVRO, "", schema) {}
+
+    operator SchemaInfo() { return schemaInfo_; }
+
+    TypedMessageBuilder<T> newMessage(const T& value) const {
+        return TypedMessageBuilder<T>{encode}.setValue(value);
+    }
+
+   private:
+    const SchemaInfo schemaInfo_;
+
+    static std::string encode(const T& value);
+};
+
+}  // namespace schema
+}  // namespace pulsar
+
+#include "avro/Decoder.hh"   // for avro::Decoder
+#include "avro/Encoder.hh"   // for avro::Encoder
+#include "avro/Specific.hh"  // for avro::encode and avro::decode
+#include "avro/Stream.hh"    // for avro::OutputStream and avro::InputStream
+
+template <typename T>
+inline std::string pulsar::schema::AvroSchema<T>::encode(const T& value) {
+    std::unique_ptr<avro::OutputStream> out = avro::memoryOutputStream();
+    std::shared_ptr<avro::Encoder> encoder = avro::binaryEncoder();
+    encoder->init(*out);
+
+    avro::encode(*encoder, value);
+
+    encoder->flush();
+
+    auto bytesPtr = avro::snapshot(*out);
+    // TODO: avoid the copy by implementing our own OutputStream
+    return std::string(bytesPtr->cbegin(), bytesPtr->cend());
+}

--- a/src/AvroSchemaExample.cc
+++ b/src/AvroSchemaExample.cc
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <pulsar/schema/AvroSchema.h>
+
+#include "avro/Decoder.hh"
+#include "avro/Encoder.hh"
+#include "avro/Specific.hh"
+
+using namespace pulsar;
+
+struct User {
+    std::string name;
+    int age;
+};
+
+namespace avro {
+template <>
+struct codec_traits<User> {
+    static void encode(avro::Encoder& e, const User& user) {
+        avro::encode(e, user.age);
+        e.encodeUnionIndex(1);
+        avro::encode(e, user.name);
+    }
+
+    static void decode(avro::Decoder& d, User& user) {
+        avro::decode(d, user.age);
+        d.decodeUnionIndex();
+        avro::decode(d, user.name);
+    }
+};
+}  // namespace avro
+
+int main() {
+    Client client("pulsar://localhost:6650");
+    // The string field must be nullable to be compatible with Java client
+    schema::AvroSchema<User> schema{R"({
+    "type": "record",
+    "namespace": "org.example",
+    "name": "User",
+    "fields": [
+        {"name": "age", "type": "int"},
+        {"name": "name", "type": ["null", "string"]}
+    ]
+})"};
+    std::string topic = "my-topic-avro";
+
+    Producer producer;
+    auto result = client.createProducer(topic, ProducerConfiguration{}.setSchema(schema), producer);
+    if (result != ResultOk) {
+        std::cerr << "Failed to create producer: " << result;
+        return 1;
+    }
+
+    MessageId msgId;
+    result = producer.send(schema.newMessage(User{"xyz", 18}).build(), msgId);
+    if (result != ResultOk) {
+        std::cerr << "Failed to send: " << result << std::endl;
+        return 2;
+    }
+    std::cout << "Sent to " << msgId << std::endl;
+
+    client.close();
+    return 0;
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,3 +32,32 @@ message(STATUS "PULSAR_LIBRARIES: ${PULSAR_LIBRARIES}")
 add_executable(IntSchemaExample IntSchemaExample.cc)
 target_include_directories(IntSchemaExample PUBLIC ../include ${PULSAR_INCLUDE_DIRS})
 target_link_libraries(IntSchemaExample ${PULSAR_LIBRARIES})
+
+# Required by avro-cpp
+find_package(Boost REQUIRED COMPONENTS filesystem iostreams program_options regex system)
+
+find_path(AVRO_CPP_INCLUDE_DIRS NAMES "avro/Encoder.hh")
+if (NOT AVRO_CPP_INCLUDE_DIRS)
+    message(FATAL_ERROR "Failed to find AVRO_CPP_INCLUDE_DIRS")
+endif ()
+find_library(AVRO_CPP_LIBRARIES NAMES "avrocpp")
+if (NOT AVRO_CPP_LIBRARIES)
+    message(FATAL_ERROR "Failed to find AVRO_CPP_LIBRARIES")
+endif ()
+message(STATUS "AVRO_CPP_INCLUDE_DIRS: ${AVRO_CPP_INCLUDE_DIRS}")
+message(STATUS "AVRO_CPP_LIBRARIES: ${AVRO_CPP_LIBRARIES}")
+
+add_executable(AvroSchemaExample AvroSchemaExample.cc)
+target_include_directories(AvroSchemaExample PUBLIC
+    ../include
+    ${Boost_INCLUDE_DIRS}
+    ${AVRO_CPP_INCLUDE_DIRS}
+    ${PULSAR_INCLUDE_DIRS})
+target_link_libraries(AvroSchemaExample
+    ${AVRO_CPP_LIBRARIES}
+    ${PULSAR_LIBRARIES}
+    Boost::filesystem
+    Boost::iostreams
+    Boost::program_options
+    Boost::regex
+    Boost::system)


### PR DESCRIPTION
### NOTE

`avro-cpp` doesn't provide the ability to send a union, while the string type automatically generated schema by Java client is always nullable like:

```json
{"name": "name", "type": ["null", "string"]}
```

C++ does not support the reflection. So it can only sends a union by specializing the `avro::encode` template function like:

```c++
        e.encodeUnionIndex(1);
        avro::encode(e, a_string_value);
```

We might need to provide our own trait class for encoding and decoding later.